### PR TITLE
Fixed missing dependency build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
-        "eslint": "^8.51.0"
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
   }
 }


### PR DESCRIPTION
```
  "devDependencies": {
    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
  }
```

>  check for missing dependencies before running build tools